### PR TITLE
Resolving Helm Command Timeout Issue with AKS

### DIFF
--- a/charts/server/values.yaml
+++ b/charts/server/values.yaml
@@ -21,7 +21,7 @@ service:
   # This sets the service type more information can be found here: https://kubernetes.io/docs/concepts/services-networking/service/#publishing-services-service-types
   type: ClusterIP
   # This sets the ports more information can be found here: https://kubernetes.io/docs/concepts/services-networking/service/#field-spec-ports
-  port: 80
+  port: 8080
   annotations: {}
 
 # This block is for setting up the ingress for more information can be found here: https://kubernetes.io/docs/concepts/services-networking/ingress/


### PR DESCRIPTION
This PR aims to resolve the issue we're experiencing when running the _helm update_ command within our scenario scripts on an AKS cluster. When attempting to install the server chart, the command times out. Here's what we know so far:

It appears that the Pods are having a permission issue binding to Port 80 (which would make sense since that port is a privileged port for AKS clusters). So, changing the port to a nonprivileged port (i.e. 8080) should allow it to bind.